### PR TITLE
Make client cards more responsive

### DIFF
--- a/ui/src/components/Clients.vue
+++ b/ui/src/components/Clients.vue
@@ -55,34 +55,61 @@
                                     </v-chip>
                                 </v-card-text>
                                 <v-card-actions>
-                                    <v-btn
-                                            text
-                                            :href="`${apiBaseUrl}/client/${client.id}/config?qrcode=false`"
-                                    >
-                                        <span class="d-none d-lg-flex">Download</span>
-                                        <v-icon right dark>mdi-cloud-download-outline</v-icon>
-                                    </v-btn>
-                                    <v-btn
+                                  <v-tooltip bottom>
+                                    <template v-slot:activator="{ on }">
+                                      <v-btn
+                                              text
+                                              :href="`${apiBaseUrl}/client/${client.id}/config?qrcode=false`"
+                                              v-on="on"
+                                      >
+                                          <span class="d-none d-lg-flex">Download</span>
+                                          <v-icon right dark>mdi-cloud-download-outline</v-icon>
+                                      </v-btn>
+                                    </template>
+                                    <span>Download</span>
+                                  </v-tooltip>
+
+                                  <v-tooltip bottom>
+                                    <template v-slot:activator="{ on }">
+                                      <v-btn
                                             text
                                             @click.stop="startUpdateClient(client)"
-                                    >
+                                            v-on="on"
+                                      >
                                         <span class="d-none d-lg-flex">Edit</span>
                                         <v-icon right dark>mdi-square-edit-outline</v-icon>
                                     </v-btn>
+                                    </template>
+                                    <span>Edit</span>
+                                  </v-tooltip>
+
+                                  <v-tooltip bottom>
+                                    <template v-slot:activator="{ on }">
                                       <v-btn
                                               text
                                               @click="deleteClient(client)"
+                                              v-on="on"
                                       >
                                           <span class="d-none d-lg-flex">Delete</span>
                                           <v-icon right dark>mdi-trash-can-outline</v-icon>
                                       </v-btn>
-                                    <v-btn
-                                            text
-                                            @click="sendEmailClient(client.id)"
-                                    >
-                                        <span class="d-none d-lg-flex">Send Email</span>
-                                        <v-icon right dark>mdi-email-send-outline</v-icon>
-                                    </v-btn>
+                                    </template>
+                                    <span>Delete</span>
+                                  </v-tooltip>
+
+                                  <v-tooltip bottom>
+                                    <template v-slot:activator="{ on }">
+                                      <v-btn
+                                              text
+                                              @click="sendEmailClient(client.id)"
+                                              v-on="on"
+                                      >
+                                          <span class="d-none d-lg-flex">Send Email</span>
+                                          <v-icon right dark>mdi-email-send-outline</v-icon>
+                                      </v-btn>
+                                    </template>
+                                    <span>Send Email</span>
+                                  </v-tooltip>
                                     <v-spacer/>
                                     <v-tooltip right>
                                         <template v-slot:activator="{ on }">

--- a/ui/src/components/Clients.vue
+++ b/ui/src/components/Clients.vue
@@ -19,7 +19,7 @@
                         <v-col
                                 v-for="(client, i) in clients"
                                 :key="i"
-                                cols="6"
+                                sm12 lg6
                         >
                             <v-card
                                     :color="client.enable ? '#1F7087' : 'warning'"
@@ -59,28 +59,28 @@
                                             text
                                             :href="`${apiBaseUrl}/client/${client.id}/config?qrcode=false`"
                                     >
-                                        Download
+                                        <span class="d-none d-lg-flex">Download</span>
                                         <v-icon right dark>mdi-cloud-download-outline</v-icon>
                                     </v-btn>
                                     <v-btn
                                             text
                                             @click.stop="startUpdateClient(client)"
                                     >
-                                        Edit
+                                        <span class="d-none d-lg-flex">Edit</span>
                                         <v-icon right dark>mdi-square-edit-outline</v-icon>
                                     </v-btn>
-                                    <v-btn
-                                            text
-                                            @click="deleteClient(client)"
-                                    >
-                                        Delete
-                                        <v-icon right dark>mdi-trash-can-outline</v-icon>
-                                    </v-btn>
+                                      <v-btn
+                                              text
+                                              @click="deleteClient(client)"
+                                      >
+                                          <span class="d-none d-lg-flex">Delete</span>
+                                          <v-icon right dark>mdi-trash-can-outline</v-icon>
+                                      </v-btn>
                                     <v-btn
                                             text
                                             @click="sendEmailClient(client.id)"
                                     >
-                                        Send email
+                                        <span class="d-none d-lg-flex">Send Email</span>
                                         <v-icon right dark>mdi-email-send-outline</v-icon>
                                     </v-btn>
                                     <v-spacer/>


### PR DESCRIPTION
This Makes the client cards more responsive by fully expanding them on mobile and removing the text from the buttons. I also added tooltips to the buttons so on smaller screens there is still more information about what the button does even though the text is gone.
Partly fixes #14. 

![screen_lg](https://user-images.githubusercontent.com/31157644/77936351-124d7500-72b3-11ea-80ce-85fd1625cde0.png)

![screen_sm](https://user-images.githubusercontent.com/31157644/77936386-1f6a6400-72b3-11ea-9480-ffcdf12678d7.png)
