### PR TITLE
mixed-up links for Backend and Frontend artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ A workaround would be to change the ```WG_INTERFACE_NAME``` to something differe
 
 ### Directly without docker
 
-Fill free to download latest artefacts from my GitLab server:
-* [Backend](https://gitlab.127-0-0-1.fr/vx3r/wg-gen-web/-/jobs/artifacts/master/download?job=build-front)
-* [Frontend](https://gitlab.127-0-0-1.fr/vx3r/wg-gen-web/-/jobs/artifacts/master/download?job=build-back)
+Fill free to download latest artifacts from my GitLab server:
+* [Backend](https://gitlab.127-0-0-1.fr/vx3r/wg-gen-web/-/jobs/artifacts/master/download?job=build-back)
+* [Frontend](https://gitlab.127-0-0-1.fr/vx3r/wg-gen-web/-/jobs/artifacts/master/download?job=build-front)
 
 Put everything in one directory, create `.env` file with all configurations and run the backend.
 


### PR DESCRIPTION
mixup in "Directly without docker" links, ie: Backend downloads the frontend files and vice versa.