### PR TITLE
Allow non IP value in DNS

### DIFF
--- a/model/server.go
+++ b/model/server.go
@@ -56,12 +56,7 @@ func (a Server) IsValid() []error {
 	if a.Mtu < 0 {
 		errs = append(errs, fmt.Errorf("MTU %d is invalid", a.PersistentKeepalive))
 	}
-	// check if the address are valid
-	for _, dns := range a.Dns {
-		if !util.IsValidIp(dns) {
-			errs = append(errs, fmt.Errorf("dns %s is invalid", dns))
-		}
-	}
+
 	// check if the allowedIPs are valid
 	for _, allowedIP := range a.AllowedIPs {
 		if !util.IsValidCidr(allowedIP) {


### PR DESCRIPTION
As the wg-quick manual say, DNS can contain `non-IP hostnames`:

> DNS — a comma-separated list of IP (v4 or v6) addresses to be set as the interface's DNS servers, or non-IP hostnames to be set as the interface's DNS search domains. [...]

I have just remove this lines in `model/server.go` :
```go
	// check if the address are valid
	for _, dns := range a.Dns {
		if !util.IsValidIp(dns) {
			errs = append(errs, fmt.Errorf("dns %s is invalid", dns))
		}
	}
```

Fix #77 