### PR TITLE
Added simplified use of a secure connection for public networks in docker compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,66 @@
+version: '3.6'
+services:
+  wg-gen-web-demo:
+    image: vx3r/wg-gen-web:latest
+    container_name: wg-gen-web-demo
+    restart: unless-stopped
+    environment:
+      - WG_CONF_DIR=/data
+      - WG_INTERFACE_NAME=wg0.conf
+#      - SMTP_HOST=smtp.gmail.com
+#      - SMTP_PORT=587
+#      - SMTP_USERNAME=no-reply@gmail.com
+#      - SMTP_PASSWORD=******************
+#      - SMTP_FROM=Wg Gen Web <no-reply@gmail.com>
+      - OAUTH2_PROVIDER_NAME=github
+      - OAUTH2_PROVIDER=https://github.com
+      - OAUTH2_CLIENT_ID=******************
+      - OAUTH2_CLIENT_SECRET=******************
+      - OAUTH2_REDIRECT_URL=https://wg.domain.com
+      - WG_STATS_API=http://172.17.0.1:8182
+      - VIRTUAL_HOST=wg.domain.com
+      - LETSENCRYPT_HOST=wg.domain.com
+      - VIRTUAL_PORT=8080
+    volumes:
+      - /etc/wireguard:/data
+
+  wg-json-api:
+    image: james/wg-api:latest
+    container_name: wg-json-api
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+    network_mode: "host"
+    command: wg-api --device wg0 --listen 172.17.0.1:8182
+
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy
+    container_name: nginx-proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - conf:/etc/nginx/conf.d
+      - vhost:/etc/nginx/vhost.d
+      - html:/usr/share/nginx/html
+      - certs:/etc/nginx/certs:ro
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+
+  acme-companion:
+    image: nginxproxy/acme-companion
+    container_name: nginx-proxy-acme
+    environment:
+      - DEFAULT_EMAIL=mail@domain.com
+    volumes_from:
+      - nginx-proxy
+    volumes:
+      - certs:/etc/nginx/certs:rw
+      - acme:/etc/acme.sh
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+volumes:
+  conf:
+  vhost:
+  html:
+  certs:
+  acme:


### PR DESCRIPTION
Added simplified use of a secure connection for public networks in docker compose configuration

VIRTUAL_HOST, LETSENCRYPT_HOST = enter domain name
DEFAULT_EMAIL = your email address to receive notifications from Let's Encrypt