### PR TITLE
Token Based Authentication for WG Stats API

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,13 @@ Wg Gen Web will only access your profile to get email address and your name, no 
 Wg Gen Web integrates a [WireGuard API implementation](https://github.com/jamescun/wg-api) to display client stats.
 In order to enable the Status API integration, the following settings need to be configured:
 ```
-# https://github.com/jamescun/wg-api integration, user and password (basic auth) are optional
+# https://github.com/jamescun/wg-api integration
 WG_STATS_API=http://<API_LISTEN_IP>:8182
+
+# Optional: Token Auth
+WG_STATS_API_TOKEN=
+
+# Optional: Basic Auth
 WG_STATS_API_USER=
 WG_STATS_API_PASS=
 ```

--- a/api/v1/client/client.go
+++ b/api/v1/client/client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 	"github.com/skip2/go-qrcode"
@@ -8,14 +10,12 @@ import (
 	"github.com/vx3r/wg-gen-web/core"
 	"github.com/vx3r/wg-gen-web/model"
 	"golang.org/x/oauth2"
-	"net/http"
 )
 
 // ApplyRoutes applies router to gin Router
 func ApplyRoutes(r *gin.RouterGroup) {
 	g := r.Group("/client")
 	{
-
 		g.POST("", createClient)
 		g.GET("/:id", readClient)
 		g.PATCH("/:id", updateClient)

--- a/core/status.go
+++ b/core/status.go
@@ -4,7 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"sort"
@@ -54,7 +55,9 @@ func fetchWireGuardAPI(reqData apiRequest) (*apiResponse, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Cache-Control", "no-cache")
 
-	if os.Getenv("WG_STATS_API_USER") != "" {
+	if os.Getenv("WG_STATS_API_TOKEN") != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Token %s", os.Getenv("WG_STATS_API_TOKEN")))
+	} else if os.Getenv("WG_STATS_API_USER") != "" {
 		req.SetBasicAuth(os.Getenv("WG_STATS_API_USER"), os.Getenv("WG_STATS_API_PASS"))
 	}
 
@@ -67,7 +70,7 @@ func fetchWireGuardAPI(reqData apiRequest) (*apiResponse, error) {
 		defer res.Body.Close()
 	}
 
-	body, readErr := ioutil.ReadAll(res.Body)
+	body, readErr := io.ReadAll(res.Body)
 	if readErr != nil {
 		return nil, readErr
 	}


### PR DESCRIPTION
Commits:

- feat(auth): Added token based auth for stats api

---

This PR adds support for `Authorization: Token <API Key>` header. It uses the `WG_STATS_API_TOKEN` ENV var to get the key. This is method is given priority over User/Pass (not even sure if that is supported). I believe, Token auth is currently the only supported mode of authentication to the stats API.