### PR TITLE
fix(dockerfile): should fix the failing CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG COMMIT
 COPY . .
 RUN go build -o wg-gen-web-linux -ldflags="-X 'github.com/vx3r/wg-gen-web/version.Version=${COMMIT}'" github.com/vx3r/wg-gen-web/cmd/wg-gen-web
 
-FROM node:lts-alpine AS build-front
+FROM node:16-alpine AS build-front
 WORKDIR /app
 COPY ui/package*.json ./
 RUN npm install


### PR DESCRIPTION
This should fix the currently failing CI. New LTS of NodeJS has some compatibility issue with OpenSSL but version 16 works fine as per my testing which I did locally.