### PR TITLE
Added support for friendly_name tag

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -234,6 +234,7 @@ PostDown = {{ .Server.PostDown }}
 {{ if .Enable -}}
 # {{.Name}} / {{.Email}} / Updated: {{.Updated}} / Created: {{.Created}}
 [Peer]
+# friendly_name = {{.Name}}
 PublicKey = {{ .PublicKey }}
 PresharedKey = {{ .PresharedKey }}
 AllowedIPs = {{ StringsJoin .Address ", " }}


### PR DESCRIPTION
This change add a coment just after the [Peer] header with the format 

```
[Peer]
# friendly_name = <username>
```

that is automatically used by the wireguard exporter for Prometheus and other tools.